### PR TITLE
Make find_buddies_with return an array; Add find_buddy_with 

### DIFF
--- a/lib/act_as_buddy/buddeable.rb
+++ b/lib/act_as_buddy/buddeable.rb
@@ -110,6 +110,15 @@ module ActAsBuddy
         def find_buddies_with(params = {})
           (raise "Argument cannot be blank." and return) if params.empty?
           (raise "Argument needs to be a hash." and return) unless params.is_a?(Hash)
+          self.class.joins(:buddy_mappers).where("buddy_mappers.buddeable_child_id=? AND #{self.class.table_name}.#{params.keys.first.to_s}=?", self.id, params.values.first.to_s)
+        end
+
+=begin
+  This function is used to find the single buddy of a parent by conditions. 
+=end
+        def find_buddy_with(params = {})
+          (raise "Argument cannot be blank." and return) if params.empty?
+          (raise "Argument needs to be a hash." and return) unless params.is_a?(Hash)
           self.class.joins(:buddy_mappers).where("buddy_mappers.buddeable_child_id=? AND #{self.class.table_name}.#{params.keys.first.to_s}=?", self.id, params.values.first.to_s).first
         end
         


### PR DESCRIPTION
I think it's more proper to return an array for method find_buddies_with, instead of returning a single record. For that purpose, I also added another method called find_buddy_with which returns first matching entry.